### PR TITLE
feat: Add ApiService

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^6.1.0",
     "@angular/platform-browser-dynamic": "^6.1.0",
     "@angular/router": "^6.1.0",
+    "angular-in-memory-web-api": "^0.6.1",
     "core-js": "^2.5.4",
     "rxjs": "~6.2.0",
     "zone.js": "~0.8.26"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
 <div>
   <app-todo-input (addTodo)="addTodo($event)"></app-todo-input>
-  <app-todo-list [todos]="todos"></app-todo-list>
+  <app-todo-list [todos]="todos$ | async"></app-todo-list>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,8 +24,10 @@ export class AppComponent implements OnInit {
 
   addTodo(event) {
     const todo = new Todo(event);
-    this.api.addTodo(todo).subscribe(
-      _ => this.api.getTodos().subscribe(v => this.todos = v)
+    this.api.addTodo(todo).pipe(
+      switchMapTo(this.api.getTodos())
+    ).subscribe(
+      v => this.todos = v
     );
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Todo } from './entities/todo';
 
+import { Observable } from 'rxjs';
 import { switchMapTo } from 'rxjs/operators';
 
 import { ApiService } from './services/api.service';
@@ -13,21 +14,19 @@ import { ApiService } from './services/api.service';
 export class AppComponent implements OnInit {
   text: string;
 
-  todos: Todo[];
+  todos$: Observable<Todo[]>;
 
   constructor(private api: ApiService) {
   }
 
   ngOnInit() {
-    this.api.getTodos().subscribe(v => this.todos = v);
+    this.todos$ = this.api.getTodos();
   }
 
   addTodo(event) {
     const todo = new Todo(event);
-    this.api.addTodo(todo).pipe(
+    this.todos$ = this.api.addTodo(todo).pipe(
       switchMapTo(this.api.getTodos())
-    ).subscribe(
-      v => this.todos = v
     );
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,21 +1,31 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Todo } from './entities/todo';
+
+import { switchMapTo } from 'rxjs/operators';
+
+import { ApiService } from './services/api.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   text: string;
 
-  todos: Todo[] = [
-    { task: 'todo1', finished: false },
-    { task: 'todo2', finished: false },
-    { task: 'todo3', finished: false }
-  ];
+  todos: Todo[];
+
+  constructor(private api: ApiService) {
+  }
+
+  ngOnInit() {
+    this.api.getTodos().subscribe(v => this.todos = v);
+  }
 
   addTodo(event) {
-    this.todos = [...this.todos, { task: event, finished: false }];
+    const todo = new Todo(event);
+    this.api.addTodo(todo).subscribe(
+      _ => this.api.getTodos().subscribe(v => this.todos = v)
+    );
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,9 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
+import { InMemoryDataService } from './in-memory-data.service';
 
 import { AppComponent } from './app.component';
 import { TodoInputComponent } from './todo-input/todo-input.component';
@@ -9,7 +12,15 @@ import { TodoListComponent } from './todo-list/todo-list.component';
 
 @NgModule({
   declarations: [AppComponent, TodoInputComponent, TodoListComponent],
-  imports: [BrowserModule, FormsModule, CommonModule],
+  imports: [
+    BrowserModule,
+    FormsModule,
+    CommonModule,
+    HttpClientModule,
+    HttpClientInMemoryWebApiModule.forRoot(
+      InMemoryDataService, { dataEncapsulation: false }
+    )
+  ],
   providers: [],
   bootstrap: [AppComponent]
 })

--- a/src/app/entities/todo.ts
+++ b/src/app/entities/todo.ts
@@ -1,4 +1,5 @@
 export class Todo {
+  public id: number;
   public task: string;
   public finished: boolean;
 

--- a/src/app/in-memory-data.service.ts
+++ b/src/app/in-memory-data.service.ts
@@ -1,0 +1,20 @@
+import { InMemoryDbService } from 'angular-in-memory-web-api';
+import { Todo } from './entities/todo';
+
+export class InMemoryDataService implements InMemoryDbService {
+  createDb() {
+    const todos: Todo[] = [
+      new Todo('todo1'),
+      new Todo('todo2'),
+      new Todo('todo3'),
+      // { task: 'todo1', finished: false },
+      // { task: 'todo2', finished: false },
+      // { task: 'todo3', finished: false }
+    ];
+    return { todos };
+  }
+
+  genId(todos: Todo[]): number {
+    return todos.length > 0 ? Math.max(...todos.map(todo => todo.id)) + 1 : 1;
+  }
+}

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ApiService } from './api.service';
+
+describe('ApiService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ApiService = TestBed.get(ApiService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Todo } from '../entities/todo';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiService {
+
+  constructor(
+    private http: HttpClient
+  ) {}
+
+
+  getTodos(): Observable<Todo[]> {
+    return this.http.get<Todo[]>('/api/todos');
+  }
+
+  addTodo(todo: Todo) {
+    return this.http.post<Todo>('/api/todos', todo);
+  }
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,6 +523,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+angular-in-memory-web-api@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/angular-in-memory-web-api/-/angular-in-memory-web-api-0.6.1.tgz#d1eb1849517fe60487c2287388606bf1c4f84dfb"
+
 ansi-colors@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.1.0.tgz#dcfaacc90ef9187de413ec3ef8d5eb981a98808f"


### PR DESCRIPTION
## WHY & WHAT

- This is an angular tutorial for https://github.com/wantedly/frontend_night/issues/23
- Add ApiService using `HttpClientModule` in `@angular/common/http`

### BASICS

1. Install `angular-in-memory-web-api`
2. Import `HttpClientModule` and `HttpClientInMemoryWebApiModule` from libraries to `AppModule`
3. Create mock database. (Just a ts file)
4. Generate `ApiService` using `@angular/cli` command (`ng g s services/api`)
5. Add functions to `ApiService` and refactor `AppComponent` to make it possible to call (mock-) WebAPI.

### ADVANCED

6. Add `switchMapTo` to avoid nested `subscribe`s
7. Use `async` pipe in angular-template.